### PR TITLE
Rewrite and benchmark XML output for IR

### DIFF
--- a/benchmark/parseBenchmark.ts
+++ b/benchmark/parseBenchmark.ts
@@ -3,6 +3,7 @@ import * as Benchmark from "benchmark";
 import { BlockElement, BlockParser } from "../src";
 import { AstHandler } from "../src/ast/AstHandler";
 import { toJSON } from "../src/output/json";
+import { formatBytes, generateBenchmarkInput } from "./utils";
 
 (function run() {
 	const input = generateBenchmarkInput();
@@ -53,31 +54,4 @@ function parse(input: string): BlockElement {
 	handler.reset();
 	parser.parse(input);
 	return handler.getResult();
-}
-
-const N_CHILDREN = 10;
-const MAX_DEPTH = 3;
-
-const LINE_CONTENT =
-	// tslint:disable-next-line:max-line-length
-	"#tag Lorem \\# ipsum #tag[dolor *sit* amet, consectetur] adipiscing elit. #tag[Integer convallis nec turpis] quis \\[ ullamcorper. _Integer_ ultricies velit accumsan volutpat viverra. Nulla et nibh \\# sed nisl interdum \\[ fringilla \\[ id in leo. #tag[Integer laoreet leo mi, _non_ accumsan] diam sodales eu. Praesent sagittis _efficitur_ turpis, non ullamcorper velit dictum ac. _In_ hac habitasse #tag[platea #tag[dictumst]. Donec molestie #tag[#tag[#tag[eros] a nisi] elementum]], eu eleifend velit #tag[blandit]. #tag[Maecenas] ac neque in sapien tempus \\\\ ullamcorper quis vel magna. Morbi sed justo quis orci mattis dapibus. #tag Nulla #tag[tristique] elit magna.\n";
-
-function generateBenchmarkInput(indent = "", depth = 0): string {
-	if (depth > MAX_DEPTH) return "";
-	return (indent + LINE_CONTENT + generateBenchmarkInput(indent + "\t", depth + 1)).repeat(
-		N_CHILDREN
-	);
-}
-
-// https://stackoverflow.com/a/18650828
-function formatBytes(bytes: number, decimals = 2) {
-	if (bytes === 0) return "0 Bytes";
-
-	const k = 1000;
-	const dm = decimals < 0 ? 0 : decimals;
-	const sizes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
-
-	const i = Math.floor(Math.log(bytes) / Math.log(k));
-
-	return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + " " + sizes[i];
 }

--- a/benchmark/utils.ts
+++ b/benchmark/utils.ts
@@ -1,0 +1,26 @@
+const N_CHILDREN = 10;
+const MAX_DEPTH = 3;
+
+const LINE_CONTENT =
+	// tslint:disable-next-line:max-line-length
+	"#tag Lorem \\# ipsum #tag[dolor *sit* amet, consectetur] adipiscing elit. #tag[Integer convallis nec turpis] quis \\[ ullamcorper. _Integer_ ultricies velit accumsan volutpat viverra. Nulla et nibh \\# sed nisl interdum \\[ fringilla \\[ id in leo. #tag[Integer laoreet leo mi, _non_ accumsan] diam sodales eu. Praesent sagittis _efficitur_ turpis, non ullamcorper velit dictum ac. _In_ hac habitasse #tag[platea #tag[dictumst]. Donec molestie #tag[#tag[#tag[eros] a nisi] elementum]], eu eleifend velit #tag[blandit]. #tag[Maecenas] ac neque in sapien tempus \\\\ ullamcorper quis vel magna. Morbi sed justo quis orci mattis dapibus. #tag Nulla #tag[tristique] elit magna.\n";
+
+export function generateBenchmarkInput(indent = "", depth = 0): string {
+	if (depth > MAX_DEPTH) return "";
+	return (indent + LINE_CONTENT + generateBenchmarkInput(indent + "\t", depth + 1)).repeat(
+		N_CHILDREN
+	);
+}
+
+// https://stackoverflow.com/a/18650828
+export function formatBytes(bytes: number, decimals = 2) {
+	if (bytes === 0) return "0 Bytes";
+
+	const k = 1000;
+	const dm = decimals < 0 ? 0 : decimals;
+	const sizes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+
+	const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+	return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + " " + sizes[i];
+}

--- a/benchmark/xmlBenchmark.ts
+++ b/benchmark/xmlBenchmark.ts
@@ -1,0 +1,26 @@
+/* tslint:disable:no-console */
+import { Event, Suite } from "benchmark";
+import { toXML } from "../src/output/xml";
+import { parse } from "../src/parser/BlockParser";
+import { formatBytes, generateBenchmarkInput } from "./utils";
+
+const input = generateBenchmarkInput();
+console.log("Size of test input: " + formatBytes(input.length));
+const ast = parse(input);
+
+new Suite("XML serialization")
+	.add("toXML", () => {
+		toXML(ast);
+	})
+	.add("JSON.stringify", () => {
+		JSON.stringify(ast, null, "\t");
+	})
+	// add listeners
+	.on("cycle", (event: Event) => {
+		console.log(String(event.target));
+	})
+	.on("complete", function(this: any[]) {
+		console.log("JSON/XML ratio: " + (this[1].stats.mean / this[0].stats.mean).toFixed(2));
+	})
+	// run async
+	.run({ async: true });

--- a/test/_resources/output/xml/block_tag.xml
+++ b/test/_resources/output/xml/block_tag.xml
@@ -1,8 +1,16 @@
 <root>
-	<section>
-		<head>Introduction</head>
-		<_default>
-			<head>Hello World</head>
-		</_default>
-	</section>
+	<content>
+		<section>
+			<title>
+				Introduction
+			</title>
+			<content>
+				<paragraph>
+					<text>
+						Hello World
+					</text>
+				</paragraph>
+			</content>
+		</section>
+	</content>
 </root>

--- a/test/_resources/output/xml/default_root.xml
+++ b/test/_resources/output/xml/default_root.xml
@@ -1,5 +1,9 @@
 <root>
-	<_default>
-		<head>Hello World</head>
-	</_default>
+	<content>
+		<paragraph>
+			<text>
+				Hello World
+			</text>
+		</paragraph>
+	</content>
 </root>

--- a/test/_resources/output/xml/empty.xml
+++ b/test/_resources/output/xml/empty.xml
@@ -1,1 +1,3 @@
-<root/>
+<root>
+	<content/>
+</root>

--- a/test/_resources/output/xml/escape.xml
+++ b/test/_resources/output/xml/escape.xml
@@ -1,14 +1,24 @@
 <root>
-	<_default>
-		<head>Lorem # Ipsum</head>
-	</_default>
-	<_default>
-		<head># Lorem Ipsum</head>
-	</_default>
-	<_default>
-		<head>Lorem Ispum #</head>
-	</_default>
-	<_default>
-		<head>\ # [ ]</head>
-	</_default>
+	<content>
+		<paragraph>
+			<text>
+				Lorem # Ipsum
+			</text>
+		</paragraph>
+		<paragraph>
+			<text>
+				# Lorem Ipsum
+			</text>
+		</paragraph>
+		<paragraph>
+			<text>
+				Lorem Ispum #
+			</text>
+		</paragraph>
+		<paragraph>
+			<text>
+				\ # [ ]
+			</text>
+		</paragraph>
+	</content>
 </root>

--- a/test/_resources/output/xml/escape_shrug.xml
+++ b/test/_resources/output/xml/escape_shrug.xml
@@ -1,5 +1,9 @@
 <root>
-	<_default>
-		<head>¯\_(ツ)_/¯</head>
-	</_default>
+	<content>
+		<paragraph>
+			<text>
+				¯\_(ツ)_/¯
+			</text>
+		</paragraph>
+	</content>
 </root>

--- a/test/_resources/output/xml/inline_in_head.xml
+++ b/test/_resources/output/xml/inline_in_head.xml
@@ -1,5 +1,15 @@
 <root>
-	<paragraph>
-		<head>text <inline>attr</inline> text</head>
-	</paragraph>
+	<content>
+		<paragraph>
+			<text>
+				text 
+				<inline>
+					<inlineContent>
+						attr
+					</inlineContent>
+				</inline>
+				 text
+			</text>
+		</paragraph>
+	</content>
 </root>

--- a/test/_resources/output/xml/inline_multiple_arguments.xml
+++ b/test/_resources/output/xml/inline_multiple_arguments.xml
@@ -1,8 +1,16 @@
 <root>
-	<_default>
-		<head><link>
-			<arg>www.example.com</arg>
-			<arg>Example</arg>
-		</link></head>
-	</_default>
+	<content>
+		<paragraph>
+			<text>
+				<link>
+					<url>
+						www.example.com
+					</url>
+					<text>
+						Example
+					</text>
+				</link>
+			</text>
+		</paragraph>
+	</content>
 </root>

--- a/test/_resources/output/xml/inline_simple.xml
+++ b/test/_resources/output/xml/inline_simple.xml
@@ -1,5 +1,13 @@
 <root>
-	<_default>
-		<head><strong>id</strong></head>
-	</_default>
+	<content>
+		<paragraph>
+			<text>
+				<strong>
+					<text>
+						id
+					</text>
+				</strong>
+			</text>
+		</paragraph>
+	</content>
 </root>

--- a/test/_resources/output/xml/inline_without_brackets.xml
+++ b/test/_resources/output/xml/inline_without_brackets.xml
@@ -1,5 +1,13 @@
 <root>
-	<paragraph>
-		<head>lorem <inline/> ipsum</head>
-	</paragraph>
+	<content>
+		<paragraph>
+			<text>
+				lorem 
+				<inline>
+					<inlineContent/>
+				</inline>
+				 ipsum
+			</text>
+		</paragraph>
+	</content>
 </root>

--- a/test/_resources/output/xml/raw_xml.xml
+++ b/test/_resources/output/xml/raw_xml.xml
@@ -1,26 +1,28 @@
 <root>
-	<_default>
-		<head>Here&apos;s an example XML tag: <code>&lt;test id=&quot;test&quot;&gt;Hello world&lt;/test&gt;</code></head>
-	</_default>
-	<_default>
-		<head>Here&apos;s a more complete code sample:</head>
-	</_default>
-	<code>
-		<head>xml</head>
-		<_default>
-			<head>&lt;!-- This should be all be escaped in the XML output &lt;test&gt; &amp; &lt;example&gt; --&gt;</head>
-		</_default>
-		<_default>
-			<head>&lt;example id=&quot;example&quot;&gt;</head>
-			<_default>
-				<head>&lt;test/&gt;</head>
-			</_default>
-			<_default>
-				<head>&lt;test id=&apos;hello&apos;&gt;world &amp; planet&lt;/test&gt;</head>
-			</_default>
-		</_default>
-		<_default>
-			<head>&lt;/example&gt;</head>
-		</_default>
-	</code>
+	<content>
+		<paragraph>
+			<text>
+				Here&apos;s an example XML tag: 
+				<code>
+					<content>
+						&lt;test id=&quot;test&quot;&gt;Hello world&lt;/test&gt;
+					</content>
+				</code>
+			</text>
+		</paragraph>
+		<paragraph>
+			<text>
+				Here&apos;s a more complete code sample:
+			</text>
+		</paragraph>
+		<code>
+			<content>
+				&lt;!-- This should be all be escaped in the XML output &lt;test&gt; &amp; &lt;example&gt; --&gt;
+				&lt;example id=&quot;example&quot;&gt;
+				&#09;&lt;test/&gt;
+				&#09;&lt;test id=&apos;hello&apos;&gt;world &amp; planet&lt;/test&gt;
+				&lt;/example&gt;
+			</content>
+		</code>
+	</content>
 </root>

--- a/test/output/xmlTest.ts
+++ b/test/output/xmlTest.ts
@@ -1,0 +1,115 @@
+import { assert } from "chai";
+import { HMError } from "../../src";
+import { IRBlockHandler } from "../../src/ir/IRBlockHandler";
+import { IRNode } from "../../src/ir/IRNode";
+import { toXML } from "../../src/output/xml";
+import { BlockParser } from "../../src/parser/BlockParser";
+import { Schema } from "../../src/schema/Schema";
+import { Cardinality, ROOT, SchemaDefinition } from "../../src/schema/SchemaDefinition";
+import { filePairs } from "../utils";
+
+describe("xml", () => {
+	const errors: HMError[] = [];
+	const logger = (x: HMError) => errors.push(x);
+	let parse: (input: string) => IRNode;
+	const makeParser = (schema: SchemaDefinition) => {
+		const handler = new IRBlockHandler(new Schema(schema), logger);
+		const parser = new BlockParser(handler);
+		parse = (input: string): IRNode => {
+			handler.reset();
+			parser.parse(input);
+			return handler.getResult();
+		};
+	};
+
+	before(() => makeParser(getDocumentSchema()));
+
+	for (const [input, output] of filePairs("xml", ".xml")) {
+		it(`works with ${output.name}`, () => {
+			const ast = parse(input.read());
+			const xml = toXML(ast);
+			assert.strictEqual(xml, output.read().trim());
+		});
+	}
+});
+
+function getDocumentSchema(): SchemaDefinition {
+	const inlineTags = [
+		{ schema: "[base]", tag: "link" },
+		{ schema: "[base]", tag: "strong" },
+		{ schema: "[base]", tag: "inline" },
+		{ schema: "[base]", tag: "code" }
+	];
+	const blockContent = [
+		{ tag: "paragraph", cardinality: Cardinality.ZeroOrMore },
+		{ tag: "section", cardinality: Cardinality.ZeroOrMore },
+		{ tag: "code", cardinality: Cardinality.ZeroOrMore }
+	];
+
+	return {
+		blocks: {
+			[ROOT]: {
+				defaultTag: "paragraph",
+				props: [
+					{
+						name: "content",
+						content: blockContent
+					}
+				]
+			},
+			["paragraph"]: {
+				head: { name: "text", content: inlineTags },
+				props: []
+			},
+			["section"]: {
+				head: { name: "title", content: inlineTags },
+				defaultTag: "paragraph",
+				props: [
+					{
+						name: "content",
+						content: blockContent
+					}
+				]
+			},
+			["code"]: {
+				props: [{ name: "content", raw: true }]
+			}
+		},
+
+		inline: {
+			["link"]: {
+				sugar: {
+					start: "[",
+					separator: "](",
+					end: ")"
+				},
+				props: [
+					{ name: "url", raw: true },
+					{ name: "text", content: [{ schema: "[base]", tag: "strong" }] }
+				]
+			},
+			["strong"]: {
+				sugar: {
+					start: "*",
+					end: "*"
+				},
+				props: [{ name: "text", content: [{ schema: "[base]", tag: "link" }] }]
+			},
+			["inline"]: {
+				props: [
+					{
+						name: "inlineContent",
+						content: inlineTags
+					}
+				]
+			},
+			["code"]: {
+				props: [{ name: "content", raw: true }],
+				sugar: {
+					start: "`",
+					end: "`"
+				}
+			}
+		}
+	};
+}


### PR DESCRIPTION
This PR rewrites `toXML` for the IR. I added tests and a performance benchmark.

The previous version of `toXML` added indentation recursively (a single indent at a time), while the current one only indents them once by the correct at the very end. Surprisingly, a little performance is lost, and I don't really know why :cry: 

<details><summary>Benchmark results</summary>
Before:

```
Size of test input: 7.44 MB
toXML x 3.05 ops/sec ±9.48% (13 runs sampled)
JSON.stringify x 4.00 ops/sec ±9.25% (14 runs sampled)
JSON/XML ratio: 0.76
```

After:

```
Size of test input: 7.44 MB
toXML x 2.55 ops/sec ±4.87% (11 runs sampled)
JSON.stringify x 4.78 ops/sec ±3.21% (16 runs sampled)
JSON/XML ratio: 0.53
```

</details>