### PR TITLE
Add Typedoc documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ typings/
 
 # next.js build output
 .next
+
+# Typedoc output
+typedoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,27 @@ cache:
   - node_modules
 notifications:
   email: false
+env:
+  matrix:
+    secure: f0Miqm9zC//imy3uTxTn2kMi9rUlxrTe/3VNyW2O2+nM8aXu3wcmlXX1/wsSBH4SiQcNSedsdRZcfldeTzcP/IT0VGXOMlqKKRlwFB99WDVETngPD9b5XYb0wT7ujC4nvB8iVQW9M24CDADbi41fbJVA1Mgi7u7p/BZTuYIXn8WfIj97jjihx2MmjuDXxZ7R01TJDulcFDAMH86PM2lRByj5WA6ZYqtBrljVgkQDU/cqbb6i16devxEeGAJK2XluFo5qN5xl+gbqDHlbIn/QC0vi+/B3fBdaLy2K/FGmXYsdmkJQ0w2dDhQ7p/+MOL8jfGCbRSZMa2614Zw6vUD8Z480rVUmd0wTJbA/S3DAZYB5dI5y+q3RgNaLNzJD7fh+2K2EihpHmX6+Sgg+9Ta7N9jkMVOMrusTMZe2oDwRhUznJjXzmomSAv2mEQS8z0t0+xVFRA2XNKRVFMkOtkwruLrE2ELbgwgCUX/2wFCG1u1auL6cfxp8werLGYxo4iwQSrQVtDsVTxsAMyWoQLfyzEAnMjwAbrTjgwQnGtZ0qb8cAJgj7XJo0yz46km6/CDTvUBbfApCDGzvMIN9tNwp11vjs6fTxG7ii4bOmxtUxG4Gj+U3LeVsgkCZnhmQnnumH7GJ7wBom9RaB0E0zvMOP5jgMdRinLwOFGZPUKF9MRE=
 script:
 - npm run build
 - npm run format:check
 - npm run tslint
 - npm run coveralls
+- npm run docs
 deploy:
+- provider: npm
   skip_cleanup: true
-  provider: npm
   email: maxime.kjaer@gmail.com
   api_key:
     secure: PLy5Ud4b9OU5KFLRsQRchZn7KnWDruDDOoxpdJrl23j5LN3b5r7fsb42I2lV03eY42lxbkH7vzPC4CZUyhdkkYhrjqHBTEACYQfD/7q82SlHip/6NqKvXn0XddEFGUuPu9zFyv2Hv5E3ZYMoVccJ8JFikLljWWLznTmlyvezJaFMIQHeCJgQmiW7ZudaTT9zLMV2TQ2jpFvXHyslXSjxCaF1eYNVTWN6vwYZIzEpCWAifNzdNcDunfFMZkzIDroPsM+EU17Cy3cT+fmZam6TWB7P+6mOlZRLVFw2b1tm4rvwQrHf0+SBbmb8RIcFt9ZGLgF8pygxkrMB42iyyzA/H9yC6qhV0D9MDv9NP36AW1gpnPOswvtvCOA2l+g0J8tvOCy50gZFImPLGch8DtVOHB1SRckeShpKApnmvClMhYO85dpyYtjl8jYLVfK8KpudJJMdJ/mk2C32faV6/OM4EQFBYAt52WCxDIHRT0Nr26MjDOQ3Kc7apSt+p3JEzg4d5vEDe2L5aGAJDsfrlKQ9OYxdy55kwwvafWIHt2VUXPoOIFXHo0ToVJ1+0CuEb7hSYig7JY51kPekLLEgGin89TxZY1oXAUOR+H4Ja5lRKw8w8KM5jORi/Cst7pJA/VTIQwX6I/fL01h25ee7f9jf6TA6sAMxJhn7hWtnSeyneKc=
   on:
     tags: true
-    repo: "hashml/hashml"
+    repo: hashml/hashml
+- provider: pages
+  skip_cleanup: true
+  local_dir: typedoc
+  github_token: "$GITHUB_TOKEN"
+  on:
+    branch: master

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,6 +140,12 @@
 			"integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==",
 			"dev": true
 		},
+		"@types/minimatch": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+			"dev": true
+		},
 		"@types/mocha": {
 			"version": "5.2.7",
 			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
@@ -265,6 +271,15 @@
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
 			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
 			"dev": true
+		},
+		"backbone": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
+			"integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
+			"dev": true,
+			"requires": {
+				"underscore": ">=1.8.3"
+			}
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -806,6 +821,17 @@
 				"mime-types": "^2.1.12"
 			}
 		},
+		"fs-extra": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			}
+		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -952,6 +978,12 @@
 			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
 			"dev": true
 		},
+		"highlight.js": {
+			"version": "9.15.9",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.9.tgz",
+			"integrity": "sha512-M0zZvfLr5p0keDMCAhNBp03XJbKBxUx5AfyfufMdFMEP4N/Xj6dh0IqC75ys7BAzceR34NgcvXjupRVaHBPPVQ==",
+			"dev": true
+		},
 		"hosted-git-info": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
@@ -995,6 +1027,12 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
+		},
+		"interpret": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+			"integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
 			"dev": true
 		},
 		"invert-kv": {
@@ -1180,6 +1218,12 @@
 				"handlebars": "^4.1.2"
 			}
 		},
+		"jquery": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+			"integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
+			"dev": true
+		},
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1231,6 +1275,15 @@
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 			"dev": true
+		},
+		"jsonfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.6"
+			}
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -1336,6 +1389,12 @@
 				"yallist": "^2.1.2"
 			}
 		},
+		"lunr": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.6.tgz",
+			"integrity": "sha512-swStvEyDqQ85MGpABCMBclZcLI/pBIlu8FFDtmX197+oEgKloJ67QnB+Tidh0340HmLMs39c4GrkPY3cmkXp6Q==",
+			"dev": true
+		},
 		"make-dir": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -1365,6 +1424,12 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
 			"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+			"dev": true
+		},
+		"marked": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
+			"integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
 			"dev": true
 		},
 		"mem": {
@@ -1915,6 +1980,12 @@
 			"integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
 			"dev": true
 		},
+		"progress": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+			"dev": true
+		},
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -1974,6 +2045,15 @@
 			"requires": {
 				"find-up": "^3.0.0",
 				"read-pkg": "^3.0.0"
+			}
+		},
+		"rechoir": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+			"dev": true,
+			"requires": {
+				"resolve": "^1.1.6"
 			}
 		},
 		"redent": {
@@ -2097,6 +2177,17 @@
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 			"dev": true
+		},
+		"shelljs": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+			"integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.0.0",
+				"interpret": "^1.0.0",
+				"rechoir": "^0.6.2"
+			}
 		},
 		"signal-exit": {
 			"version": "3.0.2",
@@ -2375,6 +2466,45 @@
 			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
 			"dev": true
 		},
+		"typedoc": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.15.0.tgz",
+			"integrity": "sha512-NOtfq5Tis4EFt+J2ozhVq9RCeUnfEYMFKoU6nCXCXUULJz1UQynOM+yH3TkfZCPLzigbqB0tQYGVlktUWweKlw==",
+			"dev": true,
+			"requires": {
+				"@types/minimatch": "3.0.3",
+				"fs-extra": "^8.1.0",
+				"handlebars": "^4.1.2",
+				"highlight.js": "^9.15.8",
+				"lodash": "^4.17.15",
+				"marked": "^0.7.0",
+				"minimatch": "^3.0.0",
+				"progress": "^2.0.3",
+				"shelljs": "^0.8.3",
+				"typedoc-default-themes": "^0.6.0",
+				"typescript": "3.5.x"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				}
+			}
+		},
+		"typedoc-default-themes": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.6.0.tgz",
+			"integrity": "sha512-MdTROOojxod78CEv22rIA69o7crMPLnVZPefuDLt/WepXqJwgiSu8Xxq+H36x0Jj3YGc7lOglI2vPJ2GhoOybw==",
+			"dev": true,
+			"requires": {
+				"backbone": "^1.4.0",
+				"jquery": "^3.4.1",
+				"lunr": "^2.3.6",
+				"underscore": "^1.9.1"
+			}
+		},
 		"typescript": {
 			"version": "3.5.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
@@ -2400,6 +2530,18 @@
 					"optional": true
 				}
 			}
+		},
+		"underscore": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+			"integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
+			"dev": true
+		},
+		"universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true
 		},
 		"uri-js": {
 			"version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"source-map-support": "^0.5.12",
 		"ts-node": "^8.3.0",
 		"tslint": "^5.18.0",
+		"typedoc": "^0.15.0",
 		"typescript": "^3.5.2"
 	},
 	"scripts": {
@@ -48,6 +49,7 @@
 		"coverage": "nyc mocha --require source-map-support/register",
 		"coveralls": "npm run coverage && nyc report --reporter=text-lcov | coveralls",
 		"check": "npm test && npm run format:check && npm run tslint",
+		"docs": "typedoc --out typedoc src/",
 		"preversion": "npm run check",
 		"postversion": "git push && git push --tags",
 		"benchmark": "node --require ts-node/register benchmark/parseBenchmark.ts"

--- a/src/output/xml.ts
+++ b/src/output/xml.ts
@@ -1,5 +1,14 @@
 import { IRNode, IRNodeList } from "../ir/IRNode";
 
+/**
+ * Convert an IR tree to an XML string.
+ * Child nodes are indented with a tab `\t` character.
+ *
+ * @param root Root of the IR tree
+ * @param indentation Indentation level
+ *
+ * @returns Tab-indented XML representation of the IR tree.
+ */
 export function toXML(root: IRNode, indentation: number = 0): string {
 	const children = Object.entries(root.props).map(([tag, nodeList]) =>
 		propToXML(tag, nodeList, indentation + 1)

--- a/src/parser/BlockHandler.ts
+++ b/src/parser/BlockHandler.ts
@@ -1,8 +1,41 @@
 import { InputPosition } from "./InputPosition";
 
+/**
+ * A `BlockHandler` builds a data structure from instructions from the {@link BlockParser}.
+ */
 export interface BlockHandler {
+	/**
+	 * Open a block tag.
+	 *
+	 * @param tag name of the tag, or `undefined` if the tag is not explicitly named
+	 * @param pos position of the start of the block
+	 *
+	 * @returns `true` if the block body is raw, `false` otherwise
+	 */
 	openBlock(tag: string | undefined, pos: InputPosition): boolean;
-	head(tag: string | undefined, pos: InputPosition): void;
+
+	/**
+	 * Receive the head content of the currently open block.
+	 *
+	 * It is the responsibility of the block handler to further parse the head content
+	 * (i.e. call the {@link InlineParser} if needed).
+	 *
+	 * @param content raw content of the head
+	 * @param pos position of the head content
+	 */
+	head(content: string, pos: InputPosition): void;
+
+	/**
+	 * Close the currently open block.
+	 *
+	 * @param pos start position of the block
+	 */
 	closeBlock(pos: InputPosition): void;
+
+	/**
+	 *
+	 * @param content
+	 * @param pos
+	 */
 	rawLine(content: string, pos: InputPosition): void;
 }

--- a/src/parser/BlockParser.ts
+++ b/src/parser/BlockParser.ts
@@ -4,12 +4,11 @@ import { InputPosition } from "./InputPosition";
 
 /**
  * Parses Hashml blocks. A block is a Hashml tag with a body. For example:
+ *
  * ```
  * #block head
  * 		block content
  * ```
- *
- * @typeparam BlockData		Type of produced block objects
  */
 export class BlockParser {
 	private readonly regex = /(?:\r\n|\n|\r|^)(\t*)(.*)/gm;

--- a/src/schema/schema-generators.ts
+++ b/src/schema/schema-generators.ts
@@ -11,18 +11,78 @@ import {
 
 // Cardinality:
 
+/**
+ * Allow a tag to appear once or more within a prop.
+ *
+ * Usage example:
+ *
+ * ```ts
+ * prop("content", [oneOrMore("bar")])
+ * ```
+ *
+ * This defines a `content` prop that may contain one or more occurrences of `#bar`
+ *
+ * @param tag Name of the tag to allow
+ * @returns A cardinality rule for a prop in a block body
+ * @category Cardinality
+ */
 export function oneOrMore(tag: string): BlockPropContentDefinition {
 	return { tag, cardinality: Cardinality.OneOrMore };
 }
 
+/**
+ * Allow a tag to appear exactly once within a prop.
+ *
+ * Usage example:
+ *
+ * ```ts
+ * prop("content", [one("bar")])
+ * ```
+ *
+ * This defines a `content` prop that may contain only exactly one occurrence of `#bar`
+ *
+ * @param tag Name of the tag to allow
+ * @returns A cardinality rule for a prop in a block body
+ * @category Cardinality
+ */
 export function one(tag: string): BlockPropContentDefinition {
 	return { tag, cardinality: Cardinality.One };
 }
 
+/**
+ * Allow a tag to appear any number of times within a prop.
+ *
+ * Usage example:
+ *
+ * ```ts
+ * prop("content", [zeroOrMore("bar")])
+ * ```
+ *
+ * This defines a `content` prop that may contain any number of `#bar`
+ *
+ * @param tag Name of the tag to allow
+ * @returns A cardinality rule for a prop in a block body
+ * @category Cardinality
+ */
 export function zeroOrMore(tag: string): BlockPropContentDefinition {
 	return { tag, cardinality: Cardinality.ZeroOrMore };
 }
 
+/**
+ * Allow a tag to appear at most once.
+ *
+ * Usage example:
+ *
+ * ```ts
+ * prop("content", [optional("bar")])
+ * ```
+ *
+ * This defines a `content` prop that may contain zero or one occurrences of `#bar`
+ *
+ * @param tag Name of the tag to allow
+ * @returns A cardinality rule for a prop in a block body
+ * @category Cardinality
+ */
 export function optional(tag: string): BlockPropContentDefinition {
 	return { tag, cardinality: Cardinality.Optional };
 }
@@ -42,18 +102,78 @@ export function sugar(a: string, b: string, c?: string): SugarSyntax {
 
 // Props:
 
+/**
+ * Define a prop and its content.
+ *
+ * Usage example:
+ *
+ * ```ts
+ * prop("content", [zeroOrMore("foo"), optional("bar")])
+ * ```
+ *
+ * This defines a `content` prop that may contain any number of `#foo` and optionally a `#bar`.
+ *
+ * @param name Name of the prop
+ * @param content Array of allowed content. See Cardinality Functions.
+ * @category Prop
+ */
 export function prop(name: string, content: BlockPropContentDefinition[]): BlockPropDefinition {
 	return { name, content: content.flat() };
 }
 
+/**
+ * Define a raw prop.
+ *
+ *
+ * Usage example:
+ *
+ * ```ts
+ * rawProp("code")
+ * ```
+ *
+ * This defines a raw prop called `code`.
+ * The body of a raw prop is not parsed as Hashml, but instead as raw text.
+ *
+ * @param name Name of the prop
+ * @category Prop
+ */
 export function rawProp(name: string): [RawBlockPropDefinition] {
 	return [{ name, raw: true }];
 }
 
+/**
+ * Define an inline prop.
+ *
+ * Usage example:
+ *
+ * ```ts
+ * inlineProp("title", ["bold", "italic"])
+ * ```
+ *
+ * This is useful for heads of block tags, and for arguments of inline tags.
+ *
+ * @param name Name of the prop
+ * @param content Array of allowed tags
+ * @category Prop
+ */
 export function inlineProp(name: string, content: string[]): InlinePropDefinition {
 	return { name, content };
 }
 
+/**
+ * Define a raw inline prop.
+ *
+ * Usage example:
+ *
+ * ```ts
+ * rawInlineProp("url")
+ * ```
+ *
+ * This is useful for raw args and raw heads.
+ *
+ * @param name Name of the prop
+ * @category Prop
+ */
 export function rawInlineProp(name: string): RawInlinePropDefinition {
 	return { name, raw: true };
 }

--- a/src/schema/schemaErrors.ts
+++ b/src/schema/schemaErrors.ts
@@ -7,11 +7,22 @@ import {
 } from "./errors";
 import { BlockPropDefinition, RawBlockPropDefinition, SchemaDefinition } from "./SchemaDefinition";
 
-// Schema rules:
-//   1) All prop names within an element must be different
-//   2) All block prop content tags must be declared once
-//   3) The pairwise intersection of block prop contents must be empty
-
+/**
+ * Check a schema definition for errors. The rules of a schema definition are:
+ *
+ * 1. All prop names within an element must be different
+ * 2. All block prop content tags must be declared once
+ * 3. The pairwise intersection of block prop contents must be empty.
+ *
+ * There is an error for each of these rules:
+ *
+ * 1. [[DuplicatePropNameError]]
+ * 2. [[DuplicatePropTagsError]]
+ * 3. [[DuplicatePropAssignmentError]]
+ *
+ * @param schema Schema definition object.
+ * @returns Array of schema definition errors, or an empty array if no errors were found.
+ */
 export function schemaErrors(schema: SchemaDefinition): SchemaDefinitionError[] {
 	const errors: SchemaDefinitionError[] = [];
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,20 +1,64 @@
-// From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
+/**
+ * Convert a string to a regexp, escaping any special characters.
+ *
+ * From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
+ *
+ * @param regexp String that the regex will match.
+ * @category RegExp
+ */
 export function stringToRegexp(regexp: string): RegExp {
 	return new RegExp(regexp.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")); // $& means the whole matched string
 }
 
+/**
+ * Returns a union of regular expressions, in the given order.
+ *
+ * @param regExps Array of regular expressions to produce the union of
+ * @category RegExp
+ */
 export function regexpUnion(...regExps: RegExp[]): RegExp {
 	return new RegExp("(" + regExps.map(_ => `(?:${_.source})`).join("|") + ")", "g");
 }
 
+/**
+ * Returns a copy of a sequence with duplicates removed.
+ *
+ * @remarks
+ * Order of the first occurrences is preserved.
+ * To see how this implementation respects that, see [the MDN documentation for `Set`][1].
+ *
+ * [1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#Description
+ *
+ * @param seq Sequence of items, potentially with duplicates.
+ * @category Array
+ */
 export function unique<T>(seq: Iterable<T>): T[] {
 	return [...new Set<T>(seq)];
 }
 
+/**
+ * Returns the last item in a sequence.
+ *
+ * @remarks
+ * If the last item does not exist, this function will return `undefined`.
+ * This is coherent with the behavior of arrays in TS, but means that this function should only
+ * be called when we know that a last item exists.
+ *
+ * @typeparam T Type of the items in the sequence
+ * @param seq String, array, or other array-like sequence
+ * @category Array
+ */
 export function last<T>(seq: ArrayLike<T>): T {
 	return seq[seq.length - 1];
 }
 
+/**
+ * Returns a map of items to their occurrence count.
+ *
+ * @typeparam T Type of the items in the array
+ * @param arr Array of repeated items
+ * @category Array
+ */
 export function countOccurrences<T>(arr: T[]): Map<T, number> {
 	const map = new Map<T, number>();
 	for (const item of arr) {
@@ -24,6 +68,12 @@ export function countOccurrences<T>(arr: T[]): Map<T, number> {
 	return map;
 }
 
+/**
+ * Returns the ordinal form of a number.
+ * For example, the ordinal of 1 is "1st".
+ *
+ * @param i Number to convert to an ordinal.
+ */
 export function ordinal(i: number): string {
 	function suffix(j: number) {
 		const tens = j % 100;


### PR DESCRIPTION
This PR adds:

- Typedoc as a dependency
- Code documentation to some exported areas of the code
- Travis CI deployment of the documentation to the `gh-pages` branch

The first deployment of the documentation will happen when this is merged onto `master`. 